### PR TITLE
createSelector 로 캐싱(메모), useMemo비교,rerender관점에서 차이

### DIFF
--- a/redux-connect/src/App.js
+++ b/redux-connect/src/App.js
@@ -1,22 +1,52 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import { useDispatch, useSelector } from "react-redux";
 import { addPost } from './actions/post';
 import { logIn, logOut } from './actions/user';
+import { createSelector } from "@reduxjs/toolkit";
 
 const userSlice = require('./reducers/user');
+
+const priceSelector = (state) => state.user.prices;
+const sumPriceSelector = createSelector( //5. 이걸 재사용하면 문제가 된다. 사용하고 싶다면 함수로 한번 더 감싸서 만들어준다. 공식문서 참조 필요.
+  priceSelector,
+  (prices) => prices.reduce((a,c) => a+c , 0)
+); //4. 이렇게 함으로 써 rerender가 훨씬 적어짐. prices가 변경되면 다시 불려짐. 그리고 컴포넌트의 rerendering과는 무관해짐. 퍼포먼스가 좋아짐.
+
+const outside = (dispatch) => () => { //curring으로 밖으로 빼서 사용 가능함. dispatch가 내부에 있어도.
+  dispatch(logIn({
+    id: 'jaess',
+    password: '1234'
+  }));
+}
+
 
 function App() {
 
   const user = useSelector((state) => state.user); //state는 initailState
   //const posts = useSelector((state) => {state.posts}); //state는 initailState
   const dispatch = useDispatch();
+  const prices = useSelector((state) => state.user.prices);
+  const [email, setEmail] = useState('');
+  const totalPriceCreateSelector = useSelector(sumPriceSelector); // 3. 해당 값이 캐싱이 되므로 상관 없음.
 
-  const onClick = useCallback(() => {
+  //setEmail로 rerender로 가격 연산은 rendering 될 때 마다 이뤄진다. 그래서 최적화를 해야함. 
+  const changeEmail = (e) => {
+    setEmail(e.target.value);
+  }
+
+  const totalPrices = useMemo(() => { 
+    console.log('memo');
+    return prices.reduce((a, b) => a + b, 0); // 1. 캐싱으로 얻는 효율이 생김.
+  },[prices]) //2. but, 만약 prices가 계속 변경된다면 위 연산보다 더 부담스럴수도 있다. 이를 해결하기 위에 createSelector다.
+
+  const onClick = useCallback(() => { 
     dispatch(logIn({
-      id :'jaess',
-      password : '1234'
+      id: 'jaess',
+      password: '1234'
     }))
   }, []);
+
+  const onClick2 = useCallback(outside(dispatch),[]); // 의존성 주입 가능함.
 
   const onLogout = useCallback(() => {
     dispatch(userSlice.actions.logOut()); //toolkit이 알아서 logout action을 생성해준다.
@@ -24,14 +54,23 @@ function App() {
 
   const onAddPost = useCallback(() => {
     dispatch(addPost());
-  },[])
+  }, [])
 
   return (
     <div>
       {user.isLogginIn ? <div>로그인중</div> : user.data ? <div>{user.data.nickname}</div> : '로그인 해주세요.'}
-      {!user.data ? <button onClick={onClick}>로그인</button> 
-      : <button onClick={onLogout}>로그아웃</button>}
-    <button onClick={onAddPost}>게시글 작성</button>
+      {!user.data ? <button onClick={onClick}>로그인</button>
+        : <button onClick={onLogout}>로그아웃</button>}
+      <button onClick={onAddPost}>게시글 작성</button>
+      <div>
+        <b>{totalPrices} 원</b>
+
+        <p><b>{totalPriceCreateSelector} 원</b></p>
+        
+      </div>
+      <div>
+        <input type='text' value={email} onChange={changeEmail} />
+      </div>
     </div>
   );
 }

--- a/redux-connect/src/reducers/user.js
+++ b/redux-connect/src/reducers/user.js
@@ -4,7 +4,8 @@ const { logIn } = require('../actions/user');
 
 const initialState = {
   isLogginIn: false,
-  data: null
+  data: null,
+  prices : Array(100).fill().map((v,i) => (i +1) * 100),
 }
 
 const userSlice = createSlice({


### PR DESCRIPTION
* useMemo를 사용하지 않으면 redering 될 때 마다 연산을 진행.
* 그래서 useMemo를 통해 연산이 필요한 경우 캐싱을 해둠. 하지만, useMemo 값 중 참조하는 값이 변하는 경우 연산과 rerendering 관점에서 생각해봐야됨
const totalPrices = useMemo(() => { 
    console.log('memo');
    return prices.reduce((a, b) => a + b, 0); // 1. 캐싱으로 얻는 효율이 생김.
  },[prices]) //2. but, 만약 prices가 계속 변경된다면 위 연산보다 더 부담스럴수도 있다. 이를 해결하기 위에 createSelector다.
* 결과적으로 import { createSelector } from "@reduxjs/toolkit"; 를 사용하여 해결함.
* 컴포넌트 밖으로 해당 연산을 빼내서 rerendering에 관여받지 않고 진행함.
* const sumPriceSelector = createSelector( 다. 공식문서 참조 필요.
  priceSelector,
  (prices) => prices.reduce((a,c) => a+c , 0)
);